### PR TITLE
Added Security Headers to the stack.yaml file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -49,6 +49,7 @@ Resources:
             Cookies:
               Forward: none
           ViewerProtocolPolicy: redirect-to-https
+          ResponseHeadersPolicyId: !Ref WebsiteCloudFrontPolicies
         PriceClass: PriceClass_All
         ViewerCertificate:
           AcmCertificateArn: !Ref 'AcmCertificateArn'

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,6 +53,32 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref 'AcmCertificateArn'
           SslSupportMethod: sni-only
+  WebsiteCloudFrontPolicies:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: Blog-Security-Header-Policy
+        Comment: The Vapor Blog security header policy
+        CustomHeadersConfig:
+          Items:
+            - Header: Content-Security-Policy-Report-Only
+              Value: default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'
+              Override: false
+        SecurityHeadersConfig:
+          ContentTypeOptions:
+            Override: false
+          FrameOptions:
+            FrameOption: DENY
+            Override: false
+          StrictTransportSecurity:
+            AccessControlMaxAgeSec: 63072000
+            IncludeSubdomains: true
+            Preload: false
+            Override: false
+          XSSProtection:
+            ModeBlock: true
+            Protection: true
+            Override: false
 Outputs:
   CloudfrontURL:
     Description: 'Cloudfront URL'


### PR DESCRIPTION
Added security headers configuration to the stack.yaml file

WebsiteCloudFrontPolicies using AWS::CloudFront::ResponseHeadersPolicy 
![image](https://user-images.githubusercontent.com/74614235/155299034-14b5f6ce-0305-4a51-8f00-981aa9b32c5e.png)

