### PR TITLE
Remove CSP-Report header and add CSP header

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -60,12 +60,10 @@ Resources:
       ResponseHeadersPolicyConfig:
         Name: Blog-Security-Header-Policy
         Comment: The Vapor Blog security header policy
-        CustomHeadersConfig:
-          Items:
-            - Header: Content-Security-Policy-Report-Only
-              Value: default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'
-              Override: false
         SecurityHeadersConfig:
+          ContentSecurityPolicy:
+              ContentSecurityPolicy: default-src 'none'; script-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'
+              Override: false
           ContentTypeOptions:
             Override: false
           FrameOptions:


### PR DESCRIPTION
Removed the CSP-Report-Only security header in favor of the CSP header

closes #22 