### PR TITLE
Fixes forums link

### DIFF
--- a/Content/posts/listening-on-both-ipv6-ipv4.md
+++ b/Content/posts/listening-on-both-ipv6-ipv4.md
@@ -6,6 +6,6 @@ author: Tim
 ---
 # How to listen to connections from both IPv4 and IPv6 addresses
 
-This [came up on the forums](recently) but is worth posting here as well for visibility. The default Vapor template listens on `127.0.0.1` which only allows local _IPv4_ connections. If you want to allow connections from other devices you need to set the hostname to `0.0.0.0`. However, again this only accepts IPv4 connections. If you want to allow IPv4 and IPv6 connections you can set the hostname to `::`. This will accept connections from all addresses on both IP stacks. 
+This [came up on the forums](https://forums.swift.org/t/ipv6/56627) but is worth posting here as well for visibility. The default Vapor template listens on `127.0.0.1` which only allows local _IPv4_ connections. If you want to allow connections from other devices you need to set the hostname to `0.0.0.0`. However, again this only accepts IPv4 connections. If you want to allow IPv4 and IPv6 connections you can set the hostname to `::`. This will accept connections from all addresses on both IP stacks. 
 
 Thanks to Cory for posting the answer!


### PR DESCRIPTION
The link to forums in the `How to listen to connections from both IPv4 and IPv6 addresses` post is broken.    
This pull request resolves that problem.