### PR TITLE
Change first issue project board workflow to use a reusable workflow

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,6 +11,18 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
+          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
+          echo '==================================='
+          echo 'Process incoming multiline'
+          echo '==================================='
+          SAVEIFS=$IFS
+          IFS=$'\n'
+          labels=($output)
+          IFS=$SAVEIFS
+          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
+          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
+          for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
+          
           echo '::set-output name=matrix::${{ toJson(github.event.issue.labels_url) }}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
@@ -25,14 +37,6 @@ jobs:
     steps:
       - name: retrieve labels and print those labels
         run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
-          echo '==================================='
-          echo 'Process incoming multiline'
-          echo '==================================='
-          SAVEIFS=$IFS
-          IFS=$'\n'
-          labels=($output)
-          IFS=$SAVEIFS
           for i in $labels; do echo $i; done
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -33,7 +33,7 @@ jobs:
           IFS=$'\n'
           labels=($output)
           IFS=$SAVEIFS
-          for i=0; i<${#labels[@]}; i++; do echo "Label $i: ${labels[$i]}"; done
+          for i in $labels; do echo $i; done
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 
     #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -22,17 +22,16 @@ jobs:
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
           for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
-          
-          echo '::set-output name=matrix::${{ toJson(github.event.issue.labels_url) }}'
+
+          echo '::set-output name=matrix::{\"include\":${{ toJson($labels) }}}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 
   manage_project_issues:
     runs-on: ubuntu-latest
     needs: setup_matrix_input 
-    #strategy:
-    #  matrix:
-    #    issueTag: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
+    strategy:
+      matrix: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
     
     steps:
       - name: retrieve labels and print those labels

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -27,11 +27,10 @@ jobs:
       matrix: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
     
     steps:
-      - name: retrieve labels and print those labels
+      - name: Sanity check to retrieve matrix name variable
         run: |
           echo ${{ matrix.name }}
-    # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
-
-    #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-    #with:
-    #  typeOfIssue: 'good first issue'
+      - name: Manage issues with reusable workflow
+        uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+        with:
+          typeOfIssue: ${{ matrix.name }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -12,7 +12,9 @@ jobs:
       - id: set-matrix 
         run: |
           output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
-          echo "::set-output name=matrix::{\"include\":$(echo $output)}"
+          output="[$output]"
+          echo $output
+          echo "::set-output name=matrix::{$(echo $output)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,19 +11,8 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
-          echo '==================================='
-          echo 'Process incoming multiline'
-          echo '==================================='
-          SAVEIFS=$IFS
-          IFS=$'\n'
-          labels=($output)
-          IFS=$SAVEIFS
-          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
-          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
-          for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
-
-          echo '::set-output name=matrix::{\"include\":${{ toJson(${labels}) }}}'
+          output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
+          echo "::set-output name=matrix::{\"include\":$(echo $output)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -23,7 +23,7 @@ jobs:
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
           for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
 
-          echo '::set-output name=matrix::{\"include\":${{ toJson($labels) }}}'
+          echo '::set-output name=matrix::{\"include\":${{ toJson(${labels}) }}}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: retrieve labels and print those labels
         run: |
-          for i in $labels; do echo $i; done
+          echo ${{ matrix.name }}
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 
     #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -13,8 +13,10 @@ jobs:
         run: |
           output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
           output="[$output]"
-          echo $output
-          echo "::set-output name=matrix::{$(echo $output)}"
+          replacement="},{"
+          json=${output//\}
+          \{/$replacement}
+          echo "::set-output name=matrix::{\"include\":$(echo $json)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 


### PR DESCRIPTION
With these changes, we are able to keep the project boards updated (and to expand upon the workflow).

This makes it so that instead of updating 40 different workflows in every repo, we only have to change 1 which is used by those 40 others
