### PR TITLE
Update the projectboard workflow to use a generic reusable workflow

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,6 +11,18 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
+          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
+          echo '==================================='
+          echo 'Process incoming multiline'
+          echo '==================================='
+          SAVEIFS=$IFS
+          IFS=$'\n'
+          labels=($output)
+          IFS=$SAVEIFS
+          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
+          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
+          for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
+          
           echo '::set-output name=matrix::${{ toJson(github.event.issue.labels_url) }}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
@@ -25,14 +37,6 @@ jobs:
     steps:
       - name: retrieve labels and print those labels
         run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
-          echo '==================================='
-          echo 'Process incoming multiline'
-          echo '==================================='
-          SAVEIFS=$IFS
-          IFS=$'\n'
-          labels=($output)
-          IFS=$SAVEIFS
           for i in $labels; do echo $i; done
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -32,6 +32,6 @@ jobs:
           echo ${{ matrix.name }}
   Manage_project_issues:
     needs: setup_matrix_input
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+    uses: BennyDeBock/ci/.github/workflows/issues-to-project-board.yml@main
     with:
       labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -33,7 +33,7 @@ jobs:
           IFS=$'\n'
           labels=($output)
           IFS=$SAVEIFS
-          for i=0; i<${#labels[@]}; i++; do echo "Label $i: ${labels[$i]}"; done
+          for i in $labels; do echo $i; done
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 
     #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -22,17 +22,16 @@ jobs:
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
           for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
-          
-          echo '::set-output name=matrix::${{ toJson(github.event.issue.labels_url) }}'
+
+          echo '::set-output name=matrix::{\"include\":${{ toJson($labels) }}}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 
   manage_project_issues:
     runs-on: ubuntu-latest
     needs: setup_matrix_input 
-    #strategy:
-    #  matrix:
-    #    issueTag: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
+    strategy:
+      matrix: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
     
     steps:
       - name: retrieve labels and print those labels

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 
-  manage_project_issues:
+  Sanity_check:
     runs-on: ubuntu-latest
     needs: setup_matrix_input 
     strategy:
@@ -30,7 +30,8 @@ jobs:
       - name: Sanity check to retrieve matrix name variable
         run: |
           echo ${{ matrix.name }}
-      - name: Manage issues with reusable workflow
-        uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-        with:
-          typeOfIssue: ${{ matrix.name }}
+  Manage_project_issues:
+    needs: setup_matrix_input
+    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+    with:
+      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -27,11 +27,10 @@ jobs:
       matrix: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
     
     steps:
-      - name: retrieve labels and print those labels
+      - name: Sanity check to retrieve matrix name variable
         run: |
           echo ${{ matrix.name }}
-    # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
-
-    #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-    #with:
-    #  typeOfIssue: 'good first issue'
+      - name: Manage issues with reusable workflow
+        uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+        with:
+          typeOfIssue: ${{ matrix.name }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -12,7 +12,9 @@ jobs:
       - id: set-matrix 
         run: |
           output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
-          echo "::set-output name=matrix::{\"include\":$(echo $output)}"
+          output="[$output]"
+          echo $output
+          echo "::set-output name=matrix::{$(echo $output)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,11 +11,13 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
-          output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
-          output="[$output]"
-          replacement="},{"
-          json=${output//\}
-          \{/$replacement}
+          output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | .name')
+          json=$(echo [$output] | sed 's/"\s"/","/g')
+
+          echo '======================'
+          echo 'Process incoming data'
+          echo '======================'
+          echo $json
           echo "::set-output name=matrix::{\"include\":$(echo $json)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,19 +11,8 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
-          echo '==================================='
-          echo 'Process incoming multiline'
-          echo '==================================='
-          SAVEIFS=$IFS
-          IFS=$'\n'
-          labels=($output)
-          IFS=$SAVEIFS
-          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]=`sed -e 's/^"//' -e 's/"$//' <<<"${labels[$i]}"`; done
-          for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
-          for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
-
-          echo '::set-output name=matrix::{\"include\":${{ toJson(${labels}) }}}'
+          output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
+          echo "::set-output name=matrix::{\"include\":$(echo $output)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -23,7 +23,7 @@ jobs:
           for (( i=0; i<${#labels[@]}; i++)) ; do labels[$i]="name: ${labels[$i]}"; done
           for (( i=0; i<${#labels[@]}; i++)) ; do echo "$i: ${labels[$i]}"; done
 
-          echo '::set-output name=matrix::{\"include\":${{ toJson($labels) }}}'
+          echo '::set-output name=matrix::{\"include\":${{ toJson(${labels}) }}}'
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -16,21 +16,9 @@ jobs:
           echo '======================'
           echo 'Process incoming data'
           echo '======================'
-          json=$(echo [$output] | sed 's/"\s"/","/g')
+          json=$(echo $output | sed 's/"\s"/","/g')
           echo $json
-
-          echo '======================'
-          echo 'Split string into array'
-          echo '======================'
-          SAVEIFS=$IFS
-          IFS=',' read -ra my_array <<< "$json"
-          IFS=$SAVEIFS
-
-          for i in "${my_array[@]}"
-          do
-              echo $i 
-          done
-          echo "::set-output name=matrix::{\"include\":$(echo $json)}"
+          echo "::set-output name=matrix::$(echo $json)"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
       

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: retrieve labels and print those labels
         run: |
-          for i in $labels; do echo $i; done
+          echo ${{ matrix.name }}
     # Output is a singular line with newlines, we have to split this into an array and use that for the matrix input
 
     #uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -12,12 +12,24 @@ jobs:
       - id: set-matrix 
         run: |
           output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | .name')
-          json=$(echo [$output] | sed 's/"\s"/","/g')
 
           echo '======================'
           echo 'Process incoming data'
           echo '======================'
+          json=$(echo [$output] | sed 's/"\s"/","/g')
           echo $json
+
+          echo '======================'
+          echo 'Split string into array'
+          echo '======================'
+          SAVEIFS=$IFS
+          IFS=',' read -ra my_array <<< "$json"
+          IFS=$SAVEIFS
+
+          for i in "${my_array[@]}"
+          do
+              echo $i 
+          done
           echo "::set-output name=matrix::{\"include\":$(echo $json)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -19,17 +19,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\":$(echo $json)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
-
-  Sanity_check:
-    runs-on: ubuntu-latest
-    needs: setup_matrix_input 
-    strategy:
-      matrix: ${{ fromJson(needs.setup_matrix_input.outputs.issueTags) }}
-    
-    steps:
-      - name: Sanity check to retrieve matrix name variable
-        run: |
-          echo ${{ matrix.name }}
+      
   Manage_project_issues:
     needs: setup_matrix_input
     uses: BennyDeBock/ci/.github/workflows/issues-to-project-board.yml@main

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -13,8 +13,10 @@ jobs:
         run: |
           output=$(curl https://api.github.com/repos/BennyDeBock/blog/issues/1/labels | jq '.[] | {name: .name}')
           output="[$output]"
-          echo $output
-          echo "::set-output name=matrix::{$(echo $output)}"
+          replacement="},{"
+          json=${output//\}
+          \{/$replacement}
+          echo "::set-output name=matrix::{\"include\":$(echo $json)}"
     outputs:
       issueTags: ${{ steps.set-matrix.outputs.matrix }}
 


### PR DESCRIPTION
This pr would update the project board workflow to use a generic reusable workflow so that we only have to update 1 workflow for updating projectboards compared to updating 40 workflows