### PR TITLE
Update tag list and tag details page to return the same page

### DIFF
--- a/Sources/Blog/Components/TagsPage.swift
+++ b/Sources/Blog/Components/TagsPage.swift
@@ -1,0 +1,63 @@
+import Plot
+import Publish
+import Foundation
+
+struct TagsPage: Component {
+    let selectedTag: Tag?
+    let context: PublishingContext<Blog>
+    let dateFormatter: DateFormatter
+
+    var items: [Item<Blog>] {
+        let sortingKeyPath: KeyPath<Item<Blog>, Date> = \.date
+        let order: Publish.SortOrder = .descending
+
+        guard let selectedTag = selectedTag else {
+            return context.allItems(sortedBy: sortingKeyPath, order: order)
+        }
+
+        return context.items(taggedWith: selectedTag, sortedBy: sortingKeyPath, order: order)
+    }
+
+    @ComponentBuilder
+    var body: Component {
+        SiteHeader(context: context, selectedSelectionID: nil)
+        Wrapper {
+            H1("Blog tags")
+            List(context.allTagLinks) { tagLink in
+                var name = tagLink.name
+                if tagLink.name == selectedTag?.string ||
+                    (tagLink.path == context.site.tagListPath && selectedTag == nil) {
+                    name = "[ " + name + " ]"
+                }
+                return ListItem {
+                    Link(name, url: tagLink.path.absoluteString)
+                }
+                .class("tag")
+            }
+            .class("all-tags")
+            .class("browse-all")
+
+            ItemList(
+                items: items,
+                site: context.site,
+                dateFormatter: dateFormatter
+            )
+        }
+        SiteFooter()
+    }
+}
+
+extension TagsPage {
+    struct TagLink {
+        var name: String
+        var path: Path
+    }
+}
+
+extension PublishingContext where Site == Blog {
+    var allTagLinks: [TagsPage.TagLink] {
+        var tagLinks = [TagsPage.TagLink(name: "View all", path: site.tagListPath)]
+        tagLinks.append(contentsOf: allTags.sorted().map { .init(name: $0.string, path: site.path(for: $0)) })
+        return tagLinks
+    }
+}

--- a/Sources/Blog/Models/TagLink.swift
+++ b/Sources/Blog/Models/TagLink.swift
@@ -1,3 +1,0 @@
-import Publish
-
-

--- a/Sources/Blog/Models/TagLink.swift
+++ b/Sources/Blog/Models/TagLink.swift
@@ -1,0 +1,3 @@
+import Publish
+
+

--- a/Sources/Blog/VaporTheme.swift
+++ b/Sources/Blog/VaporTheme.swift
@@ -102,20 +102,7 @@ private struct VaporThemeHTMLFactory: HTMLFactory {
             .lang(context.site.language),
             buildHead(for: page, context: context),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
-                Wrapper {
-                    H1("Browse all tags")
-                    List(page.tags.sorted()) { tag in
-                        ListItem {
-                            Link(tag.string,
-                                 url: context.site.path(for: tag).absoluteString
-                            )
-                        }
-                        .class("tag")
-                    }
-                    .class("all-tags")
-                }
-                SiteFooter()
+                TagsPage(selectedTag: nil, context: context, dateFormatter: dateFormatter)
             }
         )
     }
@@ -126,28 +113,7 @@ private struct VaporThemeHTMLFactory: HTMLFactory {
             .lang(context.site.language),
             buildHead(for: page, context: context),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
-                Wrapper {
-                    H1 {
-                        Text("Tagged with ")
-                        Span(page.tag.string).class("tag")
-                    }
-
-                    Link("Browse all tags",
-                        url: context.site.tagListPath.absoluteString
-                    )
-                    .class("browse-all")
-
-                    ItemList(
-                        items: context.items(
-                            taggedWith: page.tag,
-                            sortedBy: \.date,
-                            order: .descending
-                        ),
-                        site: context.site, dateFormatter: dateFormatter
-                    )
-                }
-                SiteFooter()
+                TagsPage(selectedTag: page.tag, context: context, dateFormatter: dateFormatter)
             }
         )
     }


### PR DESCRIPTION
To prepare for the upcoming website redesign this PR combines the "Browse all tags" and "Tagged with XYZ" pages into a single "Blog tags" page.