### PR TITLE
Support posts with multiple authors

### DIFF
--- a/Sources/Blog/Components/Pages/IndexPage.swift
+++ b/Sources/Blog/Components/Pages/IndexPage.swift
@@ -17,9 +17,15 @@ struct IndexPage: Component {
             Div {
                 for item in context.paginatedItems[pageNumber - 1] {
                     Div {
-                        let authorImageURL = item.metadata.authorImageURL ?? "https://design.vapor.codes/images/author-image-placeholder.png"
+                        let authors = item.metadata.allAuthors
+                        let authorImageURLs = item.metadata.allAuthorImageURLs
                         let publishDate = DateFormatter.short.string(from: item.date)
-                        let blogPostData = BlogPostExtraData(length: "\(item.readingTime.minutes) minutes read", author: .init(name: item.metadata.author, imageURL: authorImageURL), publishedDate: publishDate)
+                        let blogPostData = BlogPostExtraData(
+                            length: "\(item.readingTime.minutes) minutes read",
+                            author: .init(name: authors[0], imageURL: authorImageURLs[0]),
+                            contributingAuthors: zip(authors, authorImageURLs).dropFirst().map { .init(name: $0, imageURL: $1) },
+                            publishedDate: publishDate
+                        )
                         BlogCard(blogPostData: blogPostData, item: item, site: context.site)
                     }.class("col")
                 }

--- a/Sources/Blog/Components/Pages/TagsPage.swift
+++ b/Sources/Blog/Components/Pages/TagsPage.swift
@@ -35,9 +35,15 @@ struct TagsPage: Component {
                     Div {
                         for item in items {
                             Div {
-                                let authorImageURL = item.metadata.authorImageURL ?? "https://design.vapor.codes/images/author-image-placeholder.png"
+                                let authors = item.metadata.allAuthors
+                                let authorImageURLs = item.metadata.allAuthorImageURLs
                                 let publishDate = DateFormatter.short.string(from: item.date)
-                                let blogPostData = BlogPostExtraData(length: "\(item.readingTime.minutes) minutes read", author: .init(name: item.metadata.author, imageURL: authorImageURL), publishedDate: publishDate)
+                                let blogPostData = BlogPostExtraData(
+                                    length: "\(item.readingTime.minutes) minutes read",
+                                    author: .init(name: authors[0], imageURL: authorImageURLs[0]),
+                                    contributingAuthors: zip(authors, authorImageURLs).dropFirst().map { .init(name: $0, imageURL: $1) },
+                                    publishedDate: publishDate
+                                )
                                 BlogCard(blogPostData: blogPostData, item: item, site: context.site)
                             }.class("col")
                         }

--- a/Sources/Blog/VaporBlogTheme.swift
+++ b/Sources/Blog/VaporBlogTheme.swift
@@ -25,7 +25,6 @@ private struct VaporBlogThemeHTMLFactory: HTMLFactory {
     func makeItemHTML(for item: Item<Site>,
                       context: PublishingContext<Site>) throws -> HTML {
         let currentSite: CurrentSite = .blog
-        let authorImageURL = item.metadata.authorImageURL ?? "https://design.vapor.codes/images/author-image-placeholder.png"
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = item.date.dateFormatWithSuffix()
         let publishDate = dateFormatter.string(from: item.date)
@@ -35,7 +34,14 @@ private struct VaporBlogThemeHTMLFactory: HTMLFactory {
         } else {
             readingText = "minutes read"
         }
-        let blogPostData = BlogPostExtraData(length: "\(item.readingTime.minutes) \(readingText)", author: .init(name: item.metadata.author, imageURL: authorImageURL), publishedDate: publishDate)
+        let authors = item.metadata.allAuthors
+        let authorImageURLs = item.metadata.allAuthorImageURLs
+        let blogPostData = BlogPostExtraData(
+            length: "\(item.readingTime.minutes) \(readingText)",
+            author: .init(name: authors[0], imageURL: authorImageURLs[0]),
+            contributingAuthors: zip(authors, authorImageURLs).dropFirst().map { .init(name: $0, imageURL: $1) },
+            publishedDate: publishDate
+        )
         let body: Node<HTML.DocumentContext> = .body {
             SiteNavigation(context: context, selectedSelectionID: item.sectionID, currentSite: .blog, currentMainSitePage: nil)
             BlogPost(blogPostData: blogPostData, item: item, site: context.site)

--- a/Sources/Blog/main.swift
+++ b/Sources/Blog/main.swift
@@ -10,10 +10,32 @@ struct Blog: Website {
         case posts
     }
 
+    static var authorImagePlaceholder: String { "https://design.vapor.codes/images/author-image-placeholder.png" }
+
     struct ItemMetadata: WebsiteItemMetadata {
         // Add any site-specific metadata that you want to use here.
-        var author: String
+        var author: String?
+        var authors: String?
         var authorImageURL: String?
+        var authorImageURLs: String?
+        
+        var allAuthors: [String] {
+            let authors = ((self.author ?? "").split(separator: ";") + (self.authors ?? "").split(separator: ";"))
+                .map({ $0.trimmingCharacters(in: .whitespaces) })
+            
+            return authors.isEmpty ? ["Unknown"] : authors
+        }
+        
+        var allAuthorImageURLs: [String] {
+            var imageURLs = ((self.authorImageURL ?? "").split(separator: ";") + (self.authorImageURLs ?? "").split(separator: ";"))
+                .map({ $0.trimmingCharacters(in: .whitespaces) })
+            let numAuthors = self.allAuthors.count
+
+            if imageURLs.count < numAuthors {
+                imageURLs.append(contentsOf: Array(repeating: Blog.authorImagePlaceholder, count: numAuthors - imageURLs.count))
+            }
+            return imageURLs
+        }
     }
 
     // Update these properties to configure your website:


### PR DESCRIPTION
Metadata handling side of vapor/design#28. The design PR must be merged before this one will work properly.

The `authors` and `authorImageURLs` metadata keys are now alternate names for the existing `author` and `authorImageURL` metadata keys respectively. They are fully interchangeable.

Multiple authors may be specified as a semicolon-separated list; leading and trailing whitespace is ignored, i.e. `authors: Anonymous User; Less Anonymous User`. Multiple image URLs are specified the same way. Each URL is matched to an author such that the first URL is used for the first author, the second URL is used for the second author, and so forth. If there are more authors than URLs (or no URL is specified at all), the placeholder image is used as many times as needed. Excess URLs are ignored.
